### PR TITLE
removed characters └─▪  on input line

### DIFF
--- a/imp.zsh-theme
+++ b/imp.zsh-theme
@@ -30,5 +30,5 @@ function retcode() {}
 
 # alternate prompt with git & hg
 PROMPT=$'%{\e[0;34m%}%B┌─[%b%{\e[0m%}%{\e[1;32m%}%n%{\e[1;30m%}\e[0;34m%}%B][%b%{\e[0m%}%{\e[0;36m%}%B%m%b%{\e[0;34m%}%B:%b%{\e[0;34m%}%b%{\e[1;37m%}%~%{\e[0;34m%}%B]%b%{\e[0m%}$(mygit)$(hg_prompt_info)
-%{\e[0;34m%}%B└─▪%b'
+%{\e[0;34m%}%B%b'
 PS2=$' \e[0;34m%}%B>%{\e[0m%}%b '


### PR DESCRIPTION
Allows you to copy commands by triple-clicking on the left mouse button, then paste by clicking on the mouse wheel.
At the same time, the intelligibility of the input line does not deteriorate, but rather improves with prolonged input, because the first characters on the input lines are not the same sticks, but different letters of the previous commands.

For me, it really speeds up the work.