### PR TITLE
Check for hg-prompt in hg_prompt_info function

### DIFF
--- a/imp.zsh-theme
+++ b/imp.zsh-theme
@@ -2,7 +2,7 @@
 # on two lines for easier vgrepping
 
 function hg_prompt_info {
-  if (( $+commands[hg] )) && grep -q "prompt" ~/.hgrc; then
+  if (( $+commands[hg] )) && grep -qs "prompt" ~/.hgrc; then
     hg prompt --angle-brackets "\
 <hg:%{$fg[magenta]%}<branch>%{$reset_color%}><:%{$fg[magenta]%}<bookmark>%{$reset_color%}>\
 </%{$fg[yellow]%}<tags|%{$reset_color%}, %{$fg[yellow]%}>%{$reset_color%}>\

--- a/imp.zsh-theme
+++ b/imp.zsh-theme
@@ -2,11 +2,13 @@
 # on two lines for easier vgrepping
 
 function hg_prompt_info {
+  if (( $+commands[hg] )) && grep -q "prompt" ~/.hgrc; then
     hg prompt --angle-brackets "\
 <hg:%{$fg[magenta]%}<branch>%{$reset_color%}><:%{$fg[magenta]%}<bookmark>%{$reset_color%}>\
 </%{$fg[yellow]%}<tags|%{$reset_color%}, %{$fg[yellow]%}>%{$reset_color%}>\
 %{$fg[red]%}<status|modified|unknown><update>%{$reset_color%}<
 patches: <patches|join( → )|pre_applied(%{$fg[yellow]%})|post_applied(%{$reset_color%})|pre_unapplied(%{$fg_bold[black]%})|post_unapplied(%{$reset_color%})>>" 2>/dev/null
+  fi
 }
 
 ZSH_THEME_GIT_PROMPT_ADDED="%{$fg[cyan]%} +"


### PR DESCRIPTION
Check if hg-prompt is installed inside the hg_prompt_info function so that it returns an empty string if it isn't.

Derived from https://github.com/ohmyzsh/ohmyzsh/commit/d7948b39dc662c8072a307869135c8a7cae89cf9 to avoid [this issue](https://stackoverflow.com/questions/26542410/zsh-mercurial-help-on-every-command).